### PR TITLE
Grouped related files together into a single hyperfine command

### DIFF
--- a/SwiftBenchmarks/file_test.py
+++ b/SwiftBenchmarks/file_test.py
@@ -5,37 +5,59 @@ import subprocess
 import xcode_versions
 
 code = {
-    'StringLiteral': ['StringLiteral.swift'],
-    'StringInitializer': ['StringInitializer.swift'],
-    'StringBareInit': ['StringBareInit.swift'],
-    'StringTypedLiteral': ['StringTypedLiteral.swift'],
-    'StringTypedBareInit': ['StringTypedBareInit.swift'],
-    'IntLiteral': ['IntLiteral.swift'],
-    'IntInitializer': ['IntInitializer.swift'],
-    'IntBareInit': ['IntBareInit.swift'],
-    'IntTypedLiteral': ['IntTypedLiteral.swift'],
-    'IntTypedBareInit': ['IntTypedBareInit.swift'],
-    'DecimalLiteral': ['DecimalLiteral.swift'],
-    'NestedBareInit': ['Base.swift', 'NestedBareInit.swift'],
-    'NestedExplicitInit': ['Base.swift', 'NestedExplicitInit.swift'],
-    'NestedExplicitInitWithLeftHand': ['Base.swift', 'NestedExplicitInitWithLeftHand.swift'],
-    'LargeArrayUntyped': ['LargeArrayUntyped.swift'],
-    'LargeArrayTyped': ['LargeArrayTyped.swift'],
-    'LargeInitArray': ['LargeInitArray.swift'],
-    'LargeArrayRepeating': ['LargeArrayRepeating.swift'],
-    'NestedArrayUntyped': ['NestedArrayUntyped.swift'],
-    'NestedArrayTyped.swift': ['NestedArrayTyped.swift'],
-    'NestedDictionaryUntyped': ['NestedDictionaryUntyped.swift'],
-    'NestedDictionaryTyped': ['NestedDictionaryTyped.swift'],
-    'SimpleDictionaryUntyped': ['SimpleDictionaryUntyped.swift'],
-    'SimpleDictionaryTyped': ['SimpleDictionaryTyped.swift'],
-    'LargeUntypedMixedArray': ['LargeUntypedMixedArray.swift'],
-    'LargeTypedMixedArray': ['LargeTypedMixedArray.swift'],
-    'LargeInitMixedArray': ['LargeInitMixedArray.swift'],
-    'TypedComputedContainer': ['BookingData.swift', 'TypedComputedContainer.swift'],
-    'BareComputedContainer': ['BookingData.swift', 'BareComputedContainer.swift'],
-    'FunctionBareInit': ['FunctionData.swift', 'FunctionBareInit.swift'],
-    'FunctionTypedInit': ['FunctionData.swift', 'FunctionTypedInit.swift']
+    'String': {
+        'StringLiteral': ['StringLiteral.swift'],
+        'StringInitializer': ['StringInitializer.swift'],
+        'StringBareInit': ['StringBareInit.swift'],
+        'StringTypedLiteral': ['StringTypedLiteral.swift'],
+        'StringTypedBareInit': ['StringTypedBareInit.swift']
+    },
+    'Int': {
+        'IntLiteral': ['IntLiteral.swift'],
+        'IntInitializer': ['IntInitializer.swift'],
+        'IntBareInit': ['IntBareInit.swift'],
+        'IntTypedLiteral': ['IntTypedLiteral.swift'],
+        'IntTypedBareInit': ['IntTypedBareInit.swift']
+    },
+    'Decimal': {
+        'DecimalLiteral': ['DecimalLiteral.swift']
+    },
+    'Nested': {
+        'NestedBareInit': ['Base.swift', 'NestedBareInit.swift'],
+        'NestedExplicitInit': ['Base.swift', 'NestedExplicitInit.swift'],
+        'NestedExplicitInitWithLeftHand': ['Base.swift', 'NestedExplicitInitWithLeftHand.swift']
+    },
+    'LargeArray': {
+        'LargeArrayUntyped': ['LargeArrayUntyped.swift'],
+        'LargeArrayTyped': ['LargeArrayTyped.swift'],
+        'LargeInitArray': ['LargeInitArray.swift'],
+        'LargeArrayRepeating': ['LargeArrayRepeating.swift']
+    },
+    'NestedArray': {
+        'NestedArrayUntyped': ['NestedArrayUntyped.swift'],
+        'NestedArrayTyped.swift': ['NestedArrayTyped.swift']
+    },
+    'NestedDictionary': {
+        'NestedDictionaryUntyped': ['NestedDictionaryUntyped.swift'],
+        'NestedDictionaryTyped': ['NestedDictionaryTyped.swift']
+    },
+    'SimpleDictionary': {
+        'SimpleDictionaryUntyped': ['SimpleDictionaryUntyped.swift'],
+        'SimpleDictionaryTyped': ['SimpleDictionaryTyped.swift']
+    },
+    'LargeMixedArray': {
+        'LargeUntypedMixedArray': ['LargeUntypedMixedArray.swift'],
+        'LargeTypedMixedArray': ['LargeTypedMixedArray.swift'],
+        'LargeInitMixedArray': ['LargeInitMixedArray.swift']
+    },
+    'ComputedContainer': {
+        'TypedComputedContainer': ['BookingData.swift', 'TypedComputedContainer.swift'],
+        'BareComputedContainer': ['BookingData.swift', 'BareComputedContainer.swift']
+    },
+    'FunctionInit': {
+        'FunctionBareInit': ['FunctionData.swift', 'FunctionBareInit.swift'],
+        'FunctionTypedInit': ['FunctionData.swift', 'FunctionTypedInit.swift']
+    }
 }
 
 def set_xcode_version(path):
@@ -62,12 +84,16 @@ def run_tests_on_all_versions():
             print("\nFailed to restore the original Xcode Build Tools version.")
 
 def run_tests():
-    for i, (key, swift_files) in enumerate(code.items()):
-        # Joining all Swift file names in the list with spaces for the swiftc command
-        files_to_compile = ' '.join(swift_files)
-        command = "xcrun --kill-cache"
-        os.system(command)
-        command = f"hyperfine 'xcrun -n swiftc -typecheck {files_to_compile}' --show-output --warmup 1"
+    for group in code.values():
+        commands = []
+
+        for (key, swift_files) in group.items():
+            # Joining all Swift file names in the list with spaces for the swiftc command
+            files_to_compile = ' '.join(swift_files)
+            commands.append(f"--command-name '{key}' 'xcrun -n swiftc -typecheck {files_to_compile}'")
+        
+        commands = ' '.join(commands)
+        command = f"hyperfine --setup 'xcrun --kill-cache' --show-output --warmup 1 {commands}"
         os.system(command)
 
 def choose_xcode_version():


### PR DESCRIPTION
This groups related files together into a single hyperfine command. This allows hyperfine to show the relative differences between code that produces the same result.

I *think* this grouping is correct but I may have missed something.

## Example

The summary at the bottom is the part that's added when hyperfine is passed multiple commands.

```
Running tests on Xcode Build Tools version: 16.0
Benchmark 1: StringLiteral
  Time (mean ± σ):      1.835 s ±  0.066 s    [User: 0.110 s, System: 0.042 s]
  Range (min … max):    1.767 s …  1.936 s    10 runs
 
Benchmark 2: StringInitializer
  Time (mean ± σ):      1.912 s ±  0.061 s    [User: 0.204 s, System: 0.040 s]
  Range (min … max):    1.844 s …  2.017 s    10 runs
 
Benchmark 3: StringBareInit
  Time (mean ± σ):      2.247 s ±  0.108 s    [User: 0.426 s, System: 0.123 s]
  Range (min … max):    2.142 s …  2.473 s    10 runs
 
Benchmark 4: StringTypedLiteral
  Time (mean ± σ):      1.953 s ±  0.063 s    [User: 0.187 s, System: 0.046 s]
  Range (min … max):    1.861 s …  2.067 s    10 runs
 
Benchmark 5: StringTypedBareInit
  Time (mean ± σ):      2.348 s ±  0.073 s    [User: 0.522 s, System: 0.121 s]
  Range (min … max):    2.235 s …  2.463 s    10 runs
 
Summary
  StringLiteral ran
    1.04 ± 0.05 times faster than StringInitializer
    1.06 ± 0.05 times faster than StringTypedLiteral
    1.22 ± 0.07 times faster than StringBareInit
    1.28 ± 0.06 times faster than StringTypedBareInit
```